### PR TITLE
Added static validation script with the correct path for React Native projects

### DIFF
--- a/test_shippable_mobileapp.sh
+++ b/test_shippable_mobileapp.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+# javascript static analysis
+./node_modules/.bin/eslint -c .eslintrc -f junit js tests/js > shippable/testresults/eslint.xml


### PR DESCRIPTION
This PR adds a script with the correct path for the JavaScript files in the React Native projects ('js' instead of 'src/static') and removes the SCSS and tests commands.
